### PR TITLE
Fix a timing attack issue with CSRF token validation.

### DIFF
--- a/server/csrf.js
+++ b/server/csrf.js
@@ -13,6 +13,6 @@ csrf.create = function() {
 
 csrf.validate = function(token) {
   return tokens.some(storedToken => {
-    return storedToken === token;
+    return crypto.timingSafeEqual(storedToken, token);
   });
 };


### PR DESCRIPTION
crypto.timingSafeEqual (a constant-time string comparison method)
should be used for sensitive comparisons to avoid providing an opening
for timing attacks.